### PR TITLE
Add pkgConfigModules to more packages in gtk4 closure

### DIFF
--- a/pkgs/development/libraries/appstream/default.nix
+++ b/pkgs/development/libraries/appstream/default.nix
@@ -115,5 +115,6 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl21Plus;
     mainProgram = "appstreamcli";
     platforms = platforms.unix;
+    pkgConfigModules = [ "appstream" ];
   };
 }

--- a/pkgs/development/libraries/expat/default.nix
+++ b/pkgs/development/libraries/expat/default.nix
@@ -61,5 +61,6 @@ stdenv.mkDerivation rec {
     description = "A stream-oriented XML parser library written in C";
     platforms = platforms.all;
     license = licenses.mit; # expat version
+    pkgConfigModules = [ "expat" ];
   };
 }

--- a/pkgs/development/libraries/fontconfig/default.nix
+++ b/pkgs/development/libraries/fontconfig/default.nix
@@ -94,5 +94,6 @@ stdenv.mkDerivation rec {
     license = licenses.bsd2; # custom but very bsd-like
     platforms = platforms.all;
     maintainers = with maintainers; teams.freedesktop.members ++ [ ];
+    pkgConfigModules = [ "fontconfig" ];
   };
 }

--- a/pkgs/development/libraries/fribidi/default.nix
+++ b/pkgs/development/libraries/fribidi/default.nix
@@ -9,7 +9,7 @@
 , testers
 }:
 
-stdenv.mkDerivation (finalAttrs: rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "fribidi";
   version = "1.0.13";
 
@@ -17,7 +17,7 @@ stdenv.mkDerivation (finalAttrs: rec {
 
   # NOTE: Only URL tarball has "Have pre-generated man pages: true", which works-around upstream usage of some rare ancient `c2man` fossil application.
   src = fetchurl {
-    url = "https://github.com/fribidi/fribidi/releases/download/v${version}/${pname}-${version}.tar.xz";
+    url = with finalAttrs; "https://github.com/fribidi/fribidi/releases/download/v${version}/${pname}-${version}.tar.xz";
     sha256 = "sha256-f6FsgMgb1iL3sZjTE1baE5zDGKY/x3YSF69BMJA/VKI=";
   };
 

--- a/pkgs/development/libraries/gtk/4.x.nix
+++ b/pkgs/development/libraries/gtk/4.x.nix
@@ -67,7 +67,7 @@ let
 
 in
 
-stdenv.mkDerivation (finalAttrs: rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "gtk4";
   version = "4.12.4";
 
@@ -80,7 +80,7 @@ stdenv.mkDerivation (finalAttrs: rec {
   ];
 
   src = fetchurl {
-    url = "mirror://gnome/sources/gtk/${lib.versions.majorMinor version}/gtk-${version}.tar.xz";
+    url = with finalAttrs; "mirror://gnome/sources/gtk/${lib.versions.majorMinor version}/gtk-${version}.tar.xz";
     sha256 = "umfGSY5Vmfko7a+54IoyCt+qUKsvDab8arIlL8LVdSA=";
   };
 
@@ -110,7 +110,7 @@ stdenv.mkDerivation (finalAttrs: rec {
     wayland-scanner
   ] ++ lib.optionals vulkanSupport [
     shaderc # for glslc
-  ] ++ setupHooks;
+  ] ++ finalAttrs.setupHooks;
 
   buildInputs = [
     libxkbcommon
@@ -246,7 +246,7 @@ stdenv.mkDerivation (finalAttrs: rec {
 
     for program in ''${demos[@]}; do
       wrapProgram $dev/bin/$program \
-        --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:$out/share/gsettings-schemas/${pname}-${version}"
+        --prefix XDG_DATA_DIRS : "$GSETTINGS_SCHEMAS_PATH:$out/share/gsettings-schemas/${finalAttrs.pname}-${finalAttrs.version}"
     done
   '' + lib.optionalString x11Support ''
     # Cannot be in postInstall, otherwise _multioutDocs hook in preFixup will move right back.
@@ -282,7 +282,13 @@ stdenv.mkDerivation (finalAttrs: rec {
     license = licenses.lgpl2Plus;
     maintainers = teams.gnome.members ++ (with maintainers; [ raskin ]);
     platforms = platforms.all;
-    changelog = "https://gitlab.gnome.org/GNOME/gtk/-/raw/${version}/NEWS";
-    pkgConfigModules = ["gtk4"];
+    changelog = "https://gitlab.gnome.org/GNOME/gtk/-/raw/${finalAttrs.version}/NEWS";
+    pkgConfigModules = [
+      "gtk4"
+      "gtk4-broadway"
+      "gtk4-unix-print"
+      "gtk4-wayland"
+      "gtk4-x11"
+    ];
   };
 })

--- a/pkgs/development/libraries/libadwaita/default.nix
+++ b/pkgs/development/libraries/libadwaita/default.nix
@@ -17,9 +17,10 @@
 , xvfb-run
 , AppKit
 , Foundation
+, testers
 }:
 
-stdenv.mkDerivation rec {
+stdenv.mkDerivation (finalAttrs: {
   pname = "libadwaita";
   version = "1.4.2";
 
@@ -30,7 +31,7 @@ stdenv.mkDerivation rec {
     domain = "gitlab.gnome.org";
     owner = "GNOME";
     repo = "libadwaita";
-    rev = version;
+    rev = finalAttrs.version;
     hash = "sha256-SsQbCnNtgiRWMZerEjSSw+CU5m6bGRv8ILY/TITGtL4=";
   };
 
@@ -50,7 +51,7 @@ stdenv.mkDerivation rec {
 
   mesonFlags = [
     "-Dgtk_doc=true"
-  ] ++ lib.optionals (!doCheck) [
+  ] ++ lib.optionals (!finalAttrs.doCheck) [
     "-Dtests=false"
   ];
 
@@ -106,7 +107,10 @@ stdenv.mkDerivation rec {
 
   passthru = {
     updateScript = gnome.updateScript {
-      packageName = pname;
+      packageName = finalAttrs.pname;
+    };
+    tests.pkg-config = testers.hasPkgConfigModules {
+      package = finalAttrs.finalPackage;
     };
   };
 
@@ -117,5 +121,6 @@ stdenv.mkDerivation rec {
     license = licenses.lgpl21Plus;
     maintainers = teams.gnome.members ++ (with maintainers; [ dotlambda ]);
     platforms = platforms.unix;
+    pkgConfigModules = [ "libadwaita-1" ];
   };
-}
+})

--- a/pkgs/development/libraries/libdeflate/default.nix
+++ b/pkgs/development/libraries/libdeflate/default.nix
@@ -30,5 +30,6 @@ stdenv.mkDerivation rec {
     changelog = "https://github.com/ebiggers/libdeflate/blob/v${version}/NEWS.md";
     platforms = platforms.unix;
     maintainers = with maintainers; [ orivej kaction ];
+    pkgConfigModules = [ "libdeflate" ];
   };
 }

--- a/pkgs/development/libraries/libffi/default.nix
+++ b/pkgs/development/libraries/libffi/default.nix
@@ -75,5 +75,6 @@ stdenv.mkDerivation rec {
     license = licenses.mit;
     maintainers = with maintainers; [ matthewbauer ];
     platforms = platforms.all;
+    pkgConfigModules = [ "libffi" ];
   };
 }

--- a/pkgs/development/libraries/pixman/default.nix
+++ b/pkgs/development/libraries/pixman/default.nix
@@ -54,5 +54,6 @@ stdenv.mkDerivation rec {
     description = "A low-level library for pixel manipulation";
     license = licenses.mit;
     platforms = platforms.all;
+    pkgConfigModules = [ "pixman-1" ];
   };
 }

--- a/pkgs/development/libraries/silgraphite/graphite2.nix
+++ b/pkgs/development/libraries/silgraphite/graphite2.nix
@@ -51,6 +51,7 @@ stdenv.mkDerivation rec {
     homepage = "https://graphite.sil.org/";
     license = licenses.lgpl21;
     maintainers = [ maintainers.raskin ];
+    pkgConfigModules = [ "graphite2" ];
     mainProgram = "gr2fonttest";
     platforms = platforms.unix;
   };

--- a/pkgs/tools/compression/xz/default.nix
+++ b/pkgs/tools/compression/xz/default.nix
@@ -72,5 +72,6 @@ stdenv.mkDerivation rec {
     license = with licenses; [ gpl2Plus lgpl21Plus ];
     maintainers = with maintainers; [ sander ];
     platforms = platforms.all;
+    pkgConfigModules = [ "liblzma" ];
   };
 }


### PR DESCRIPTION
Here are some additions for PR NixOS/nixpkgs#285125.

The dependency closure of all `*.pc` files in `pkgs.gtk4.dev` are updated to have `meta.pkgConfigModules`.

Also `libadwaita` is included, because this library is commonly used with gtk4.

The dependency closure covers `Requires.private` dependencies (grey), because these are needed for static builds.

![pc-libadwaita](https://github.com/eldritch-cookie/nixpkgs/assets/1019641/aaf35d8d-71a9-4d2a-92d4-06e12e623cf6)
